### PR TITLE
Deduplicate io_total_input/output and add NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# econio (development version)
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/R/total.R
+++ b/R/total.R
@@ -15,30 +15,13 @@ io_total_input <- function(
   output_sector_type = "industry",
   same_region = FALSE
 ) {
-  input_sector_type <- rlang::arg_match(
-    input_sector_type,
-    c("industry", "import", "value_added"),
-    multiple = TRUE
+  io_total(
+    data,
+    keep_axis = "output",
+    input_sector_type = input_sector_type,
+    output_sector_type = output_sector_type,
+    same_region = same_region
   )
-  output_sector_type <- rlang::arg_match(
-    output_sector_type,
-    c("industry", "final_demand", "export", "import"),
-    multiple = TRUE
-  )
-
-  input <- data |>
-    dplyr::filter(
-      io_sector_type(.data$input) %in% input_sector_type,
-      io_sector_type(.data$output) %in% output_sector_type
-    )
-  if (same_region) {
-    input <- dibble::broadcast(
-      input * io_same_region(data),
-      dim_names = dimnames(input)
-    )
-  }
-  input |>
-    dibble::apply("output", sum)
 }
 
 #' Get total output
@@ -58,6 +41,22 @@ io_total_output <- function(
   output_sector_type = c("industry", "final_demand", "export", "import"),
   same_region = FALSE
 ) {
+  io_total(
+    data,
+    keep_axis = "input",
+    input_sector_type = input_sector_type,
+    output_sector_type = output_sector_type,
+    same_region = same_region
+  )
+}
+
+io_total <- function(
+  data,
+  keep_axis,
+  input_sector_type,
+  output_sector_type,
+  same_region
+) {
   input_sector_type <- rlang::arg_match(
     input_sector_type,
     c("industry", "import", "value_added"),
@@ -69,17 +68,17 @@ io_total_output <- function(
     multiple = TRUE
   )
 
-  output <- data |>
+  total <- data |>
     dplyr::filter(
       io_sector_type(.data$input) %in% input_sector_type,
       io_sector_type(.data$output) %in% output_sector_type
     )
   if (same_region) {
-    output <- dibble::broadcast(
-      output * io_same_region(data),
-      dim_names = dimnames(output)
+    total <- dibble::broadcast(
+      total * io_same_region(data),
+      dim_names = dimnames(total)
     )
   }
-  output |>
-    dibble::apply("input", sum)
+  total |>
+    dibble::apply(keep_axis, sum)
 }

--- a/tests/testthat/test-analysis.R
+++ b/tests/testthat/test-analysis.R
@@ -1,13 +1,19 @@
 test_that("io_production_induce returns the expected components", {
   # Noncompetitive import: final demand and export inducement only.
-  for (name in c("regional_noncompetitive_import", "multiregional_noncompetitive_import")) {
+  for (name in c(
+    "regional_noncompetitive_import",
+    "multiregional_noncompetitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
     pi <- io_production_induce(iotable)
     expect_setequal(names(pi), c("total_final_demand", "total_export"))
   }
 
   # Competitive import, closed economy: import inducement is also returned.
-  for (name in c("regional_competitive_import", "multiregional_competitive_import")) {
+  for (name in c(
+    "regional_competitive_import",
+    "multiregional_competitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
     pi <- io_production_induce(iotable, open_economy = FALSE)
     expect_setequal(
@@ -22,11 +28,17 @@ test_that("io_production_induce returns the expected components", {
 })
 
 test_that("io_self_sufficiency_rate is only defined for competitive import tables", {
-  for (name in c("regional_noncompetitive_import", "multiregional_noncompetitive_import")) {
+  for (name in c(
+    "regional_noncompetitive_import",
+    "multiregional_noncompetitive_import"
+  )) {
     expect_error(io_self_sufficiency_rate(read_iotable_dummy(name)))
   }
 
-  for (name in c("regional_competitive_import", "multiregional_competitive_import")) {
+  for (name in c(
+    "regional_competitive_import",
+    "multiregional_competitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
 
     rate_summary <- io_self_sufficiency_rate(iotable, summary = TRUE)
@@ -40,7 +52,10 @@ test_that("io_self_sufficiency_rate is only defined for competitive import table
 })
 
 test_that("io_ghosh_inverse returns an output-by-input matrix", {
-  for (name in c("regional_competitive_import", "regional_noncompetitive_import")) {
+  for (name in c(
+    "regional_competitive_import",
+    "regional_noncompetitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
     g <- io_ghosh_inverse(iotable)
     expect_equal(names(dimnames(g)), c("output", "input"))

--- a/tests/testthat/test-skyline.R
+++ b/tests/testthat/test-skyline.R
@@ -1,12 +1,24 @@
 test_that("skyline tidy data has the expected structure", {
-  for (name in c("regional_competitive_import", "multiregional_competitive_import")) {
+  for (name in c(
+    "regional_competitive_import",
+    "multiregional_competitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
 
     sky <- broom::tidy(iotable, type = "skyline")
 
     expect_s3_class(sky, "tbl_df")
     expect_true(all(
-      c("sector", "total", "xmin", "xmax", "rate_type", "rate", "ymin", "ymax") %in%
+      c(
+        "sector",
+        "total",
+        "xmin",
+        "xmax",
+        "rate_type",
+        "rate",
+        "ymin",
+        "ymax"
+      ) %in%
         names(sky)
     ))
     expect_setequal(
@@ -44,13 +56,20 @@ test_that("skyline autoplot and autolayer return ggplot objects", {
   layer_rect <- ggplot2::autolayer(iotable, type = "skyline", geom = "rect")
   expect_s3_class(layer_rect, "Layer")
 
-  layer_segment <- ggplot2::autolayer(iotable, type = "skyline", geom = "segment")
+  layer_segment <- ggplot2::autolayer(
+    iotable,
+    type = "skyline",
+    geom = "segment"
+  )
   expect_type(layer_segment, "list")
   expect_true(all(purrr::map_lgl(layer_segment, \(x) inherits(x, "Layer"))))
 })
 
 test_that("skyline is not defined for noncompetitive import tables", {
-  for (name in c("regional_noncompetitive_import", "multiregional_noncompetitive_import")) {
+  for (name in c(
+    "regional_noncompetitive_import",
+    "multiregional_noncompetitive_import"
+  )) {
     iotable <- read_iotable_dummy(name)
 
     expect_error(broom::tidy(iotable, type = "skyline"))


### PR DESCRIPTION
Extract the shared logic of io_total_input() and io_total_output() into an internal io_total() helper, preserving the existing behaviour (the same-region mask is still computed from the unfiltered table).

Also add a NEWS.md file to track user-facing changes.