### PR TITLE
Fix io_check_axes() axis mismatch test

### DIFF
--- a/tests/testthat/test-table.R
+++ b/tests/testthat/test-table.R
@@ -106,8 +106,11 @@ test_that("io_table_regional() and io_table_multiregional() work", {
 test_that("io_check_axes() detects axis mismatches", {
   iotable <- read_iotable_dummy("regional_noncompetitive_import")
   dim_names <- dimnames(iotable)
+  output_industry_sector <- dim_names$output |>
+    dplyr::filter(io_sector_type(.data$sector) == "industry") |>
+    dplyr::slice(1)
   dim_names$output <- dim_names$output |>
-    dplyr::filter(dplyr::row_number() <= dplyr::n() - 1)
+    dplyr::anti_join(output_industry_sector, by = "sector")
   iotable_mismatch <- dibble::broadcast(iotable, dim_names = dim_names)
   expect_snapshot(io_check_axes(iotable_mismatch), error = TRUE)
 })


### PR DESCRIPTION
## Summary
- The `io_check_axes() detects axis mismatches` test in `test-table.R` dropped the *last* row of the output dim_names, expecting that to produce a mismatch. In the dummy table, the last output sector is `export_1` (not an industry sector), so `io_check_axes()` — which only compares industry-type axes — never detected a mismatch, and the test silently passed without exercising the error path (`expect_snapshot(..., error = TRUE)` never failed because no snapshot mismatch occurred, but the function also never errored).
- Fix: explicitly drop the first industry-type sector instead of relying on row position.

## Test plan
- [x] `devtools::test_active_file('tests/testthat/test-table.R')` now actually exercises the error path (`Input axis mismatch: industry_1`)
- [x] `devtools::test()` — full suite passes (162 PASS, 0 FAIL)