### PR TITLE
Validate exported function arguments with rlang check_* functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     MASS,
     pillar,
     purrr,
-    rlang,
+    rlang (>= 1.1.0),
     scales,
     tibble,
     tidyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,17 @@
 
 * Added a `NEWS.md` file to track changes to the package.
 * `io_check_axes()` is now called by `io_leontief_inverse()` and `io_ghosh_inverse()` to validate that input and output industry axes match before matrix inversion, preventing errors from mismatched tables.
+* `io_check_totals()` now validates `total_tolerance` with a clearer error message.
 * `io_downstreamness()` returns the column sums of the Leontief inverse, i.e. the output multiplier (backward linkage), with a `normalize` option to obtain the power of dispersion.
+* `io_input_coef()`, `io_output_coef()`, `io_leontief_inverse()`, and `io_ghosh_inverse()` now report invalid `open_economy` values against the calling function with a clearer error message.
+* `io_reclass()` now validates `from_col`, `to_col`, `weight_col`, `weight_tolerance`, and `check_axes`.
 * `io_spectral_embedding()` returns the Laplacian spectral embedding (Fiedler vector) of the domestic production network, minimizing the graph Dirichlet energy; pair it with `io_trophic_level()` for a directed supply-chain map.
 * `io_spectral_embedding()`, `io_trophic_incoherence()` and `io_trophic_level()` now inform when they implicitly convert a competitive import type table to noncompetitive import type before building the industry network.
 * `io_spectral_embedding()`, `io_trophic_incoherence()` and `io_trophic_level()` now inform and zero out negative domestic intermediate transactions (e.g. from byproduct treatment such as the Stone method) before building the industry network, instead of producing an ill-defined result.
+* `io_spectral_embedding()` now reports an invalid `dims` argument with a clearer error message.
+* `io_table_regional()` and `io_table_multiregional()` now validate `check_axes`, `competitive_import`, and `total_tolerance`.
+* `io_table_to_competitive_import()`, `io_table_to_noncompetitive_import()`, and `io_table_to_regional()` now validate their sector-name and tolerance arguments.
+* `io_total_input()` and `io_total_output()` now validate `same_region`.
 * `io_trophic_incoherence()` returns the trophic incoherence of the domestic production network.
 * `io_trophic_level()` returns the directed-network trophic level of each industry, following MacKay, Johnson and Sansom (2020).
 * `io_upstreamness()` returns the row sums of the Ghosh inverse, i.e. the forward linkage.

--- a/R/coef.R
+++ b/R/coef.R
@@ -133,11 +133,17 @@ io_output_coef <- function(data, open_economy = NULL) {
 
 # import ------------------------------------------------------------------
 
-io_open_economy <- function(data, open_economy) {
+io_open_economy <- function(
+  data,
+  open_economy,
+  arg = rlang::caller_arg(open_economy),
+  call = rlang::caller_env()
+) {
   if (inherits(data, "io_table_noncompetitive_import")) {
     if (!is.null(open_economy)) {
       cli::cli_abort(
-        "{.code open_economy = NULL} is required for {.cls {class(data)}}."
+        "{.code open_economy = NULL} is required for {.cls {class(data)}}.",
+        call = call
       )
     }
   } else if (inherits(data, "io_table_competitive_import")) {
@@ -146,8 +152,8 @@ io_open_economy <- function(data, open_economy) {
       cli::cli_inform(
         "Assuming {.code open_economy = {open_economy}}."
       )
-    } else if (!rlang::is_scalar_logical(open_economy)) {
-      cli::cli_abort('{.code open_economy} must be a scalar logical.')
+    } else {
+      rlang::check_bool(open_economy, arg = arg, call = call)
     }
   }
   open_economy

--- a/R/reclass.R
+++ b/R/reclass.R
@@ -27,6 +27,12 @@ io_reclass <- function(
   weight_tolerance = .Machine$double.eps^0.5,
   check_axes = TRUE
 ) {
+  rlang::check_string(from_col)
+  rlang::check_string(to_col)
+  rlang::check_string(weight_col)
+  rlang::check_number_decimal(weight_tolerance, min = 0)
+  rlang::check_bool(check_axes)
+
   dim_names <- dimnames(data)
   dim_name_input <- dim_names$input
   dim_name_output <- dim_names$output

--- a/R/spectral.R
+++ b/R/spectral.R
@@ -46,11 +46,7 @@ io_spectral_embedding <- function(data, dims = 1) {
   network <- io_industry_network(data)
   n_industry <- ncol(network$laplacian)
 
-  if (!rlang::is_scalar_integerish(dims) || dims < 1 || dims > n_industry - 1) {
-    cli::cli_abort(
-      "{.arg dims} must be a scalar integer between 1 and {n_industry - 1}."
-    )
-  }
+  rlang::check_number_whole(dims, min = 1, max = n_industry - 1)
 
   decomposition <- eigen(network$laplacian, symmetric = TRUE)
   # Eigenvalues are returned in decreasing order, so the trivial constant mode

--- a/R/streamness.R
+++ b/R/streamness.R
@@ -44,6 +44,8 @@ NULL
 #' @rdname io_streamness
 #' @export
 io_upstreamness <- function(data, open_economy = NULL, normalize = FALSE) {
+  rlang::check_bool(normalize)
+
   ghosh_inverse <- io_ghosh_inverse(data, open_economy = open_economy)
   upstreamness <- dibble::apply(ghosh_inverse, "output", sum) |>
     dplyr::rename(industry = "output")
@@ -53,6 +55,8 @@ io_upstreamness <- function(data, open_economy = NULL, normalize = FALSE) {
 #' @rdname io_streamness
 #' @export
 io_downstreamness <- function(data, open_economy = NULL, normalize = FALSE) {
+  rlang::check_bool(normalize)
+
   leontief_inverse <- io_leontief_inverse(data, open_economy = open_economy)
   downstreamness <- dibble::apply(leontief_inverse, "input", sum) |>
     dplyr::rename(industry = "input")
@@ -60,9 +64,6 @@ io_downstreamness <- function(data, open_economy = NULL, normalize = FALSE) {
 }
 
 io_normalize <- function(x, normalize) {
-  if (!rlang::is_scalar_logical(normalize)) {
-    cli::cli_abort("{.arg normalize} must be a scalar logical.")
-  }
   if (normalize) {
     n <- vctrs::vec_size(dimnames(x)[[1]])
     x <- x * (n / sum(x))

--- a/R/table-to.R
+++ b/R/table-to.R
@@ -16,6 +16,9 @@ io_table_to_competitive_import <- function(
   import_sector_name = NA_character_,
   import_total_tolerance = .Machine$double.eps^0.5
 ) {
+  rlang::check_string(import_sector_name, allow_na = TRUE)
+  rlang::check_number_decimal(import_total_tolerance, min = 0)
+
   if (inherits(data, "io_table_competitive_import")) {
     return(data)
   }
@@ -91,6 +94,9 @@ io_table_to_noncompetitive_import <- function(
   import_sector_name = NA_character_,
   import_total_tolerance = .Machine$double.eps^0.5
 ) {
+  rlang::check_string(import_sector_name, allow_na = TRUE)
+  rlang::check_number_decimal(import_total_tolerance, min = 0)
+
   if (inherits(data, "io_table_noncompetitive_import")) {
     return(data)
   }
@@ -219,6 +225,9 @@ io_table_to_regional <- function(
   export_sector_name = NA_character_,
   import_sector_name = NA_character_
 ) {
+  rlang::check_string(export_sector_name, allow_na = TRUE)
+  rlang::check_string(import_sector_name, allow_na = TRUE)
+
   region <- io_region(data)
 
   blocks <- io_table_to_blocks(data)

--- a/R/table.R
+++ b/R/table.R
@@ -28,6 +28,9 @@ io_table_regional <- function(
   total_tolerance = .Machine$double.eps^0.5,
   check_axes = TRUE
 ) {
+  rlang::check_number_decimal(total_tolerance, min = 0)
+  rlang::check_bool(check_axes)
+
   input_names <- names(tidyselect::eval_select(rlang::enquo(input_cols), data))
   output_names <- names(tidyselect::eval_select(
     rlang::enquo(output_cols),
@@ -106,6 +109,9 @@ io_table_multiregional <- function(
   total_tolerance = .Machine$double.eps^0.5,
   check_axes = TRUE
 ) {
+  rlang::check_number_decimal(total_tolerance, min = 0)
+  rlang::check_bool(check_axes)
+
   input_names <- names(tidyselect::eval_select(rlang::enquo(input_cols), data))
   output_names <- names(tidyselect::eval_select(
     rlang::enquo(output_cols),
@@ -165,7 +171,9 @@ io_competitive_import <- function(
   data,
   input_sector_type,
   output_sector_type,
-  competitive_import
+  competitive_import,
+  arg = rlang::caller_arg(competitive_import),
+  call = rlang::caller_env()
 ) {
   if (is.null(competitive_import)) {
     input_sector_type <- data |>
@@ -191,9 +199,7 @@ io_competitive_import <- function(
     )
   }
 
-  if (!rlang::is_scalar_logical(competitive_import)) {
-    cli::cli_abort('{.code competitive_import} must be a scalar logical.')
-  }
+  rlang::check_bool(competitive_import, arg = arg, call = call)
   competitive_import
 }
 
@@ -252,6 +258,8 @@ io_add_region <- function(data, axis, region) {
 #'
 #' @export
 io_check_totals <- function(data, total_tolerance = .Machine$double.eps^0.5) {
+  rlang::check_number_decimal(total_tolerance, min = 0)
+
   if (dibble::ncol(data) != 1) {
     cli::cli_abort(
       "An input-output table must have only one column of amounts."

--- a/R/total.R
+++ b/R/total.R
@@ -15,6 +15,8 @@ io_total_input <- function(
   output_sector_type = "industry",
   same_region = FALSE
 ) {
+  rlang::check_bool(same_region)
+
   io_total(
     data,
     keep_axis = "output",
@@ -41,6 +43,8 @@ io_total_output <- function(
   output_sector_type = c("industry", "final_demand", "export", "import"),
   same_region = FALSE
 ) {
+  rlang::check_bool(same_region)
+
   io_total(
     data,
     keep_axis = "input",

--- a/tests/testthat/_snaps/coef.md
+++ b/tests/testthat/_snaps/coef.md
@@ -3,7 +3,7 @@
     Code
       io_input_coef(iotable_noncomp, open_economy = TRUE)
     Condition
-      Error in `io_open_economy()`:
+      Error in `io_input_coef()`:
       ! `open_economy = NULL` is required for <io_table_noncompetitive_import/io_table_regional/econ_io_table/ddf_col>.
 
 ---
@@ -11,7 +11,7 @@
     Code
       io_output_coef(iotable_noncomp, open_economy = FALSE)
     Condition
-      Error in `io_open_economy()`:
+      Error in `io_output_coef()`:
       ! `open_economy = NULL` is required for <io_table_noncompetitive_import/io_table_regional/econ_io_table/ddf_col>.
 
 ---
@@ -19,14 +19,14 @@
     Code
       io_input_coef(iotable_comp, open_economy = "yes")
     Condition
-      Error in `io_open_economy()`:
-      ! `open_economy` must be a scalar logical.
+      Error in `io_input_coef()`:
+      ! `open_economy` must be `TRUE` or `FALSE`, not the string "yes".
 
 ---
 
     Code
       io_output_coef(iotable_comp, open_economy = c(TRUE, FALSE))
     Condition
-      Error in `io_open_economy()`:
-      ! `open_economy` must be a scalar logical.
+      Error in `io_output_coef()`:
+      ! `open_economy` must be `TRUE` or `FALSE`, not a logical vector.
 

--- a/tests/testthat/_snaps/reclass.md
+++ b/tests/testthat/_snaps/reclass.md
@@ -1,0 +1,24 @@
+# io_reclass() validates its scalar arguments
+
+    Code
+      io_reclass(iotable, weight_tolerance = "x")
+    Condition
+      Error in `io_reclass()`:
+      ! `weight_tolerance` must be a number, not the string "x".
+
+---
+
+    Code
+      io_reclass(iotable, check_axes = "yes")
+    Condition
+      Error in `io_reclass()`:
+      ! `check_axes` must be `TRUE` or `FALSE`, not the string "yes".
+
+---
+
+    Code
+      io_reclass(iotable, from_col = 1)
+    Condition
+      Error in `io_reclass()`:
+      ! `from_col` must be a single string, not the number 1.
+

--- a/tests/testthat/_snaps/spectral.md
+++ b/tests/testthat/_snaps/spectral.md
@@ -4,5 +4,5 @@
       io_spectral_embedding(iotable, dims = 0)
     Condition
       Error in `io_spectral_embedding()`:
-      ! `dims` must be a scalar integer between 1 and 2.
+      ! `dims` must be a whole number between 1 and 2, not the number 0.
 

--- a/tests/testthat/_snaps/streamness.md
+++ b/tests/testthat/_snaps/streamness.md
@@ -2,9 +2,7 @@
 
     Code
       io_downstreamness(iotable, normalize = "yes")
-    Message
-      Assuming `open_economy = FALSE`.
     Condition
-      Error in `io_normalize()`:
-      ! `normalize` must be a scalar logical.
+      Error in `io_downstreamness()`:
+      ! `normalize` must be `TRUE` or `FALSE`, not the string "yes".
 

--- a/tests/testthat/_snaps/table-to.md
+++ b/tests/testthat/_snaps/table-to.md
@@ -1,0 +1,16 @@
+# io_table_to_*() validate their scalar arguments
+
+    Code
+      io_table_to_competitive_import(iotable, import_sector_name = 5)
+    Condition
+      Error in `io_table_to_competitive_import()`:
+      ! `import_sector_name` must be a single string or `NA`, not the number 5.
+
+---
+
+    Code
+      io_table_to_noncompetitive_import(iotable, import_total_tolerance = "x")
+    Condition
+      Error in `io_table_to_noncompetitive_import()`:
+      ! `import_total_tolerance` must be a number, not the string "x".
+

--- a/tests/testthat/_snaps/table.md
+++ b/tests/testthat/_snaps/table.md
@@ -150,6 +150,38 @@
       x industry_2: 174 (`actual`) not nearly equal to 174.142857142857 (`expected`).
       x industry_3: 165 (`actual`) not nearly equal to 165.142857142857 (`expected`).
 
+# io_table_regional() validates its scalar arguments
+
+    Code
+      io_table_regional(data, competitive_import = TRUE, check_axes = "yes")
+    Condition
+      Error in `io_table_regional()`:
+      ! `check_axes` must be `TRUE` or `FALSE`, not the string "yes".
+
+---
+
+    Code
+      io_table_regional(data, competitive_import = TRUE, total_tolerance = -1)
+    Condition
+      Error in `io_table_regional()`:
+      ! `total_tolerance` must be a number larger than or equal to 0, not the number -1.
+
+---
+
+    Code
+      io_table_regional(data, competitive_import = "yes")
+    Condition
+      Error in `io_table_regional()`:
+      ! `competitive_import` must be `TRUE` or `FALSE`, not the string "yes".
+
+# io_check_totals() validates total_tolerance
+
+    Code
+      io_check_totals(iotable, total_tolerance = "x")
+    Condition
+      Error in `io_check_totals()`:
+      ! `total_tolerance` must be a number, not the string "x".
+
 # io_check_axes() detects axis mismatches
 
     Code

--- a/tests/testthat/_snaps/total.md
+++ b/tests/testthat/_snaps/total.md
@@ -1,0 +1,16 @@
+# io_total_input() and io_total_output() validate same_region
+
+    Code
+      io_total_input(iotable, same_region = NA)
+    Condition
+      Error in `io_total_input()`:
+      ! `same_region` must be `TRUE` or `FALSE`, not `NA`.
+
+---
+
+    Code
+      io_total_output(iotable, same_region = "x")
+    Condition
+      Error in `io_total_output()`:
+      ! `same_region` must be `TRUE` or `FALSE`, not the string "x".
+

--- a/tests/testthat/test-reclass.R
+++ b/tests/testthat/test-reclass.R
@@ -50,3 +50,10 @@ test_that("io_reclass() works", {
     )
   }
 })
+
+test_that("io_reclass() validates its scalar arguments", {
+  iotable <- read_iotable_dummy("regional_competitive_import")
+  expect_snapshot(io_reclass(iotable, weight_tolerance = "x"), error = TRUE)
+  expect_snapshot(io_reclass(iotable, check_axes = "yes"), error = TRUE)
+  expect_snapshot(io_reclass(iotable, from_col = 1), error = TRUE)
+})

--- a/tests/testthat/test-table-to.R
+++ b/tests/testthat/test-table-to.R
@@ -95,3 +95,15 @@ test_that("io_table_to_regional() works", {
     expect_equal(total_input_regional, total_input)
   }
 })
+
+test_that("io_table_to_*() validate their scalar arguments", {
+  iotable <- read_iotable_dummy("regional_noncompetitive_import")
+  expect_snapshot(
+    io_table_to_competitive_import(iotable, import_sector_name = 5),
+    error = TRUE
+  )
+  expect_snapshot(
+    io_table_to_noncompetitive_import(iotable, import_total_tolerance = "x"),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-table.R
+++ b/tests/testthat/test-table.R
@@ -103,6 +103,28 @@ test_that("io_table_regional() and io_table_multiregional() work", {
   }
 })
 
+test_that("io_table_regional() validates its scalar arguments", {
+  iotable_dummy <- readRDS(test_path("data", "iotable_dummy.rds"))
+  data <- iotable_dummy$regional_competitive_import
+  expect_snapshot(
+    io_table_regional(data, competitive_import = TRUE, check_axes = "yes"),
+    error = TRUE
+  )
+  expect_snapshot(
+    io_table_regional(data, competitive_import = TRUE, total_tolerance = -1),
+    error = TRUE
+  )
+  expect_snapshot(
+    io_table_regional(data, competitive_import = "yes"),
+    error = TRUE
+  )
+})
+
+test_that("io_check_totals() validates total_tolerance", {
+  iotable <- read_iotable_dummy("regional_competitive_import")
+  expect_snapshot(io_check_totals(iotable, total_tolerance = "x"), error = TRUE)
+})
+
 test_that("io_check_axes() detects axis mismatches", {
   iotable <- read_iotable_dummy("regional_noncompetitive_import")
   dim_names <- dimnames(iotable)

--- a/tests/testthat/test-total.R
+++ b/tests/testthat/test-total.R
@@ -1,0 +1,5 @@
+test_that("io_total_input() and io_total_output() validate same_region", {
+  iotable <- read_iotable_dummy("regional_competitive_import")
+  expect_snapshot(io_total_input(iotable, same_region = NA), error = TRUE)
+  expect_snapshot(io_total_output(iotable, same_region = "x"), error = TRUE)
+})


### PR DESCRIPTION
Standardize input validation on the tidyverse check_* family. Convert ad-hoc rlang::is_scalar_* + cli_abort checks to rlang::check_bool(), check_number_whole(), and check_number_decimal(), and add missing validation at exported entry points (check_axes, same_region, tolerance numerics, sector-name strings).

Internal helpers io_open_economy() and io_competitive_import() gain arg and call arguments so errors surface at the user-facing entry point.