### PR TITLE
Fix io_table_to_noncompetitive_import() leaving stray import output sector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * `io_streamness_position()` is a new experimental function that returns the net position of each industry within the supply chain, derived from `io_upstreamness()` and `io_downstreamness()`, with a `type` argument to choose between their difference, a `[-1, 1]`-bounded relative difference, or a log ratio.
 * `io_table_regional()` and `io_table_multiregional()` now validate `check_axes`, `competitive_import`, and `total_tolerance`.
 * `io_table_to_competitive_import()`, `io_table_to_noncompetitive_import()`, and `io_table_to_regional()` now validate their sector-name and tolerance arguments.
+* `io_table_to_noncompetitive_import()` no longer leaves a leftover zero-valued `import` sector on the output axis when converting from a competitive import type table.
 * `io_total_input()` and `io_total_output()` now validate `same_region`.
 * `io_trophic_incoherence()` returns the trophic incoherence of the domestic production network.
 * `io_trophic_level()` returns the directed-network trophic level of each industry, following MacKay, Johnson and Sansom (2020).

--- a/R/table-to.R
+++ b/R/table-to.R
@@ -140,6 +140,9 @@ io_table_to_noncompetitive_import <- function(
     dibble::broadcast(dim_names = c("input", "output"))
   import <- import * io_same_region(import)
 
+  data <- data |>
+    dplyr::filter(io_sector_type(.data$output) != "import")
+
   dim_names <- dimnames(data)
   dim_names$input <- vctrs::vec_rbind(
     dim_names$input |>
@@ -150,7 +153,6 @@ io_table_to_noncompetitive_import <- function(
   )
 
   out <- data |>
-    dplyr::filter(io_sector_type(.data$output) != "import") |>
     dibble::broadcast(dim_names = dim_names) |>
     dibble::broadcast(dim_names = c("input", "output")) |>
     dplyr::rows_update(regional_demand) |>

--- a/tests/testthat/test-table-to.R
+++ b/tests/testthat/test-table-to.R
@@ -53,6 +53,15 @@ test_that("io_table_to_noncompetitive_import() works", {
       io_total_input(iotable_dummy_noncompetitive_import),
       io_total_input(iotable_dummy)
     )))
+    expect_length(
+      which(
+        io_sector_type(
+          dimnames(iotable_dummy_noncompetitive_import)$output$sector
+        ) ==
+          "import"
+      ),
+      0
+    )
   }
 })
 


### PR DESCRIPTION
## Summary
- `io_table_to_noncompetitive_import()` built `dim_names` from the unfiltered source data, so when converting from a competitive import type table, the subsequent `dibble::broadcast()` reintroduced a zero-valued `import` sector on the output axis instead of dropping it.
- Filter `data` to exclude `output == "import"` before deriving `dim_names`, matching the same filter already applied to build the output table.

## Test plan
- [x] `devtools::test_active_file('tests/testthat/test-table-to.R')` passes, including a new assertion that no `import` sector remains on the output axis after conversion.
- [x] `devtools::test()` passes (200 tests).